### PR TITLE
Remove path for the ipset executable to make it work on non-redhat based distribution

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,8 +31,9 @@ define ipset (
   include ipset::base
 
   if $ensure == 'absent' {
-    exec { "/usr/sbin/ipset destroy ${title}":
-      onlyif  => "/usr/sbin/ipset list ${title} &>/dev/null",
+    exec { "ipset destroy ${title}":
+      onlyif  => "ipset list ${title} &>/dev/null",
+      path    => [ '/sbin', '/usr/sbin', '/bin', '/usr/bin' ],
       require => Package['ipset'],
     }
   } else {
@@ -47,7 +48,7 @@ define ipset (
       $command = "/usr/local/sbin/ipset_from_file -n ${title} -f ${from_file} -t \"${ipset_type}\" -c \"${ipset_create_options}\" -a \"${ipset_add_options}\""
       exec { "ipset-create-${name}":
         command   => $command,
-        unless    => "/usr/sbin/ipset list ${title}",
+        unless    => "ipset list ${title}",
         require   => Package['ipset'],
         path      => [ '/sbin', '/usr/sbin', '/bin', '/usr/bin' ],
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,7 @@ define ipset (
       exec { "ipset-create-${name}":
         command   => $command,
         unless    => "ipset list ${title}",
+        logoutput => false,
         require   => Package['ipset'],
         path      => [ '/sbin', '/usr/sbin', '/bin', '/usr/bin' ],
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,7 @@ define ipset (
       $command = "/usr/local/sbin/ipset_from_file -n ${title} -f ${from_file} -t \"${ipset_type}\" -c \"${ipset_create_options}\" -a \"${ipset_add_options}\""
       exec { "ipset-create-${name}":
         command   => $command,
-        unless    => "ipset list ${title}",
+        unless    => "ipset list ${title} >/dev/null",
         logoutput => false,
         require   => Package['ipset'],
         path      => [ '/sbin', '/usr/sbin', '/bin', '/usr/bin' ],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,7 @@ define ipset (
         command     => $command,
         subscribe   => File[$from_file],
         refreshonly => true,
+        logoutput   => false,
         require     => Package['ipset'],
         path        => [ '/sbin', '/usr/sbin', '/bin', '/usr/bin' ],
       }

--- a/manifests/iptables.pp
+++ b/manifests/iptables.pp
@@ -58,9 +58,9 @@ define ipset::iptables (
   $target_name = regsubst($target,'^([^ ]+).*$','\1')
   # Strict vs. looser matching
   if $strictmatch {
-    $iptables_match = "iptables-save | egrep \"^-A ${chain} .+ -m set --match-set ${ipset} ${flags} .*${options}.*-j ${target_name}\""
+    $iptables_match = "iptables-save | egrep \"^-A ${chain} -m set --match-set ${ipset} ${flags} .*${options}.*-j ${target_name}\""
   } else {
-    $iptables_match = "iptables-save | egrep \"^-A ${chain} .+ -m set --match-set ${ipset} ${flags} .*-j ${target_name}\""
+    $iptables_match = "iptables-save | egrep \"^-A ${chain} -m set --match-set ${ipset} ${flags} .*-j ${target_name}\""
   }
 
   # Insert the rule if it's not already there

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@
 #
 class ipset::params {
 
-  $package = $::operatingsystem ? {
+  $package = $facts['os']['family'] ? {
       'Gentoo' => 'net-firewall/ipset',
        default => 'ipset',
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,10 @@
+{
+	"name": "thias-ipset",
+	"version": "0.1.0",
+	"author": "Matthias Saou",
+	"summary": "ipset module",
+	"license": "Apache-2.0",
+	"source": "git://github.com/thias/puppet-ipset",
+        "description": "Manage IP sets in the Linux kernel",
+        "project_page": "https://github.com/thias/puppet-ipset"
+}


### PR DESCRIPTION
On ubuntu based system, ipset is located in /sbin instead of /usr/sbin. 
